### PR TITLE
feature/v1.0.15-testnet - Bumps Cronos Testnet version to v1.0.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN adduser --disabled-password --gecos "" --no-create-home --uid 1000 cronos
 
 RUN mkdir -p /home/cronos/data && mkdir -p /home/cronos/config
 RUN apt-get update -y && apt-get install wget curl procps net-tools jq lz4 -y
-RUN cd /tmp && wget --no-check-certificate https://cronos-binary.s3.ap-southeast-1.amazonaws.com/cronos-v1.0.13-hardfork/cronos-v1.0.13-hardfork-x86_64.tar.gz && tar -xvf cronos-v1.0.13-hardfork-x86_64.tar.gz \
-    && rm cronos-v1.0.13-hardfork-x86_64.tar.gz && mv ./* /home/cronos/
+RUN cd /tmp && wget --no-check-certificate https://github.com/crypto-org-chain/cronos/releases/download/v1.0.15/cronos_1.0.15-testnet_Linux_x86_64.tar.gz && tar -xvf cronos_1.0.15-testnet_Linux_x86_64.tar.gz \
+    && rm cronos_1.0.15-testnet_Linux_x86_64.tar.gz && mv ./* /home/cronos/
 RUN chown -R cronos:cronos /home/cronos
 
 USER cronos


### PR DESCRIPTION
## [Changelog](https://github.com/crypto-org-chain/cronos/releases/tag/v1.0.15)

## Reason
- v1.0.15 is a non-breaking upgrade, fix two panic issues in json-rpc APIs.