### PR TITLE
Cronos mainnet image upgrade v1.4.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN adduser --disabled-password --gecos "" --no-create-home --uid 1000 cronos
 
 RUN mkdir -p /home/cronos/data && mkdir -p /home/cronos/config
 RUN apt-get update -y && apt-get install wget curl procps net-tools jq lz4 -y
-RUN cd /tmp && wget --no-check-certificate https://github.com/crypto-org-chain/cronos/releases/download/v1.4.7/cronos_1.4.7-testnet_Linux_x86_64.tar.gz && tar -xvf cronos_1.4.7-testnet_Linux_x86_64.tar.gz \
-     && rm cronos_1.4.7-testnet_Linux_x86_64.tar.gz && mv ./* /home/cronos/
+RUN cd /tmp && wget --no-check-certificate https://github.com/crypto-org-chain/cronos/releases/download/v1.4.7/cronos_1.4.7_Linux_x86_64.tar.gz && tar -xvf cronos_1.4.7_Linux_x86_64.tar.gz \
+    && rm cronos_1.4.7_Linux_x86_64.tar.gz && mv ./* /home/cronos/
 RUN chown -R cronos:cronos /home/cronos && chmod 1777 /tmp
 
 USER root


### PR DESCRIPTION
[OPS-4930](https://chainstack.myjetbrains.com/youtrack/issue/OPS-4930) Cronos v1.4.7 Upgrades across clusters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Cronos binary in the Docker image to use the mainnet version instead of the testnet version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->