### PR TITLE
chore:1.4.9-testnet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN adduser --disabled-password --gecos "" --no-create-home --uid 1000 cronos
 
 RUN mkdir -p /home/cronos/data && mkdir -p /home/cronos/config
 RUN apt-get update -y && apt-get install wget curl procps net-tools jq lz4 -y
-RUN cd /tmp && wget --no-check-certificate https://github.com/crypto-org-chain/cronos/releases/download/v1.4.9/cronos_1.4.9_Linux_x86_64.tar.gz && tar -xvf cronos_1.4.9_Linux_x86_64.tar.gz \
+RUN cd /tmp && wget --no-check-certificate https://github.com/crypto-org-chain/cronos/releases/download/v1.4.9/cronos_1.4.9-testnet_Linux_x86_64.tar.gz && tar -xvf cronos_1.4.9_Linux_x86_64.tar.gz \
     && rm cronos_1.4.9_Linux_x86_64.tar.gz && mv ./* /home/cronos/
 RUN chown -R cronos:cronos /home/cronos && chmod 1777 /tmp
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the source for downloading the cronos binary to use the testnet version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->