### PR TITLE
feat: INFRA-5312 Cronos testnet image bump v1.4.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+/.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN adduser --disabled-password --gecos "" --no-create-home --uid 1000 cronos
 
 RUN mkdir -p /home/cronos/data && mkdir -p /home/cronos/config
 RUN apt-get update -y && apt-get install wget curl procps net-tools jq lz4 -y
-RUN cd /tmp && wget --no-check-certificate https://github.com/crypto-org-chain/cronos/releases/download/v1.4.9/cronos_1.4.9_Linux_x86_64.tar.gz && tar -xvf cronos_1.4.9_Linux_x86_64.tar.gz \
-    && rm cronos_1.4.9_Linux_x86_64.tar.gz && mv ./* /home/cronos/
+RUN cd /tmp && wget --no-check-certificate https://github.com/crypto-org-chain/cronos/releases/download/v1.4.10/cronos_1.4.10-testnet_Linux_x86_64.tar.gz && tar -xvf cronos_1.4.10-testnet_Linux_x86_64.tar.gz \
+     && rm cronos_1.4.10-testnet_Linux_x86_64.tar.gz && mv ./* /home/cronos/
 RUN chown -R cronos:cronos /home/cronos && chmod 1777 /tmp
 
 USER root


### PR DESCRIPTION
New release
https://github.com/crypto-org-chain/cronos/releases/tag/v1.4.10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled Cronos to v1.4.10-testnet in the container image.
  * Added version control ignores for macOS metadata and IDE project configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->