### PR TITLE
Cronos mainnet image bump v1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN adduser --disabled-password --gecos "" --no-create-home --uid 1000 cronos
 
 RUN mkdir -p /home/cronos/data && mkdir -p /home/cronos/config
 RUN apt-get update -y && apt-get install wget curl procps net-tools jq lz4 -y
-RUN cd /tmp && wget --no-check-certificate https://github.com/crypto-org-chain/cronos/releases/download/v1.4.10/cronos_1.4.10_Linux_x86_64.tar.gz && tar -xvf cronos_1.4.10_Linux_x86_64.tar.gz \
-     && rm cronos_1.4.10_Linux_x86_64.tar.gz && mv ./* /home/cronos/
+RUN cd /tmp && wget --no-check-certificate https://github.com/crypto-org-chain/cronos/releases/download/v1.5.0/cronos_1.5.0_Linux_x86_64.tar.gz && tar -xvf cronos_1.5.0_Linux_x86_64.tar.gz \
+     && rm cronos_1.5.0_Linux_x86_64.tar.gz && mv ./* /home/cronos/
 RUN chown -R cronos:cronos /home/cronos && chmod 1777 /tmp
 
 USER root


### PR DESCRIPTION
[INFRA-5557](https://chainstack.myjetbrains.com/youtrack/issue/INFRA-5557) Cronos v1.5.0 Upgrades across clusters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Chores
  - Upgraded the container’s bundled Cronos runtime to v1.5.0 for improved stability and compatibility.

- Impact
  - Users running the container benefit from upstream fixes and improvements included in Cronos 1.5.0 without changing usage or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->