### PR TITLE
feat: INFRA-5557 Cronos testnet image bump v1.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN adduser --disabled-password --gecos "" --no-create-home --uid 1000 cronos
 
 RUN mkdir -p /home/cronos/data && mkdir -p /home/cronos/config
 RUN apt-get update -y && apt-get install wget curl procps net-tools jq lz4 -y
-RUN cd /tmp && wget --no-check-certificate https://github.com/crypto-org-chain/cronos/releases/download/v1.5.0/cronos_1.5.0_Linux_x86_64.tar.gz && tar -xvf cronos_1.5.0_Linux_x86_64.tar.gz \
-     && rm cronos_1.5.0_Linux_x86_64.tar.gz && mv ./* /home/cronos/
+RUN cd /tmp && wget --no-check-certificate https://github.com/crypto-org-chain/cronos/releases/download/v1.5.0/cronos_1.5.0-testnet_Linux_x86_64.tar.gz && tar -xvf cronos_1.5.0-testnet_Linux_x86_64.tar.gz \
+     && rm cronos_1.5.0-testnet_Linux_x86_64.tar.gz && mv ./* /home/cronos/
 RUN chown -R cronos:cronos /home/cronos && chmod 1777 /tmp
 
 USER root


### PR DESCRIPTION
[INFRA-5557](https://chainstack.myjetbrains.com/youtrack/issue/INFRA-5557) Cronos v1.5.0 Upgrades across clusters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker image now uses the Cronos testnet binary by default, aligning the container with testnet environments.
  * Download, extraction, and startup flow remain unchanged; no modifications to entrypoint, user, or permissions.
  * Users running the image will connect to testnet out of the box; switch binaries if mainnet is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->