### PR TITLE
feat: INFRA-6582 Cronos testnet image upgrade v1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN mkdir -p /home/cronos/data && mkdir -p /home/cronos/config
 RUN apt-get update -y && apt-get install wget curl procps net-tools jq lz4 -y
 
 # Download and verify tarball
-RUN cd /tmp && wget --no-check-certificate https://github.com/crypto-org-chain/cronos/releases/download/v1.5.4/cronos_1.5.4_Linux_x86_64.tar.gz && tar -xvf cronos_1.5.4_Linux_x86_64.tar.gz \
-     && rm cronos_1.5.4_Linux_x86_64.tar.gz && mv ./* /home/cronos/
+RUN cd /tmp && wget --no-check-certificate https://github.com/crypto-org-chain/cronos/releases/download/v1.6.0/cronos_1.6.0-testnet_Linux_x86_64.tar.gz && tar -xvf cronos_1.6.0-testnet_Linux_x86_64.tar.gz \
+     && rm cronos_1.6.0-testnet_Linux_x86_64.tar.gz && mv ./* /home/cronos/
 
 # Set permissions
 RUN chown -R cronos:cronos /home/cronos && chmod 1777 /tmp


### PR DESCRIPTION
Cronos testnet image upgrade v1.6.0
[INFRA-6582](https://chainstack.myjetbrains.com/youtrack/issue/INFRA-6582) Cronos v1.6.0 Upgrades across clusters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image to use Cronos v1.6.0-testnet (previously v1.5.4)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->